### PR TITLE
Change reset popup type for unexpected management key error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "pbyk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64ct",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "pbykcorelib"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64ct",
  "certval",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "pbyklib"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes",
  "base64ct",

--- a/pbyk/Cargo.toml
+++ b/pbyk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbyk"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88.0"
 

--- a/pbyk/src/gui/app.rs
+++ b/pbyk/src/gui/app.rs
@@ -182,7 +182,7 @@ pub(crate) fn app(
                                     }
                                 }
                                 Err(e) => {
-                                    let err = format!("The YubiKey with serial number {serial} is not using the expected management key. Please reset the device then try again.");
+                                    let err = format!("The YubiKey with serial number {serial} has not been configured for use with Purebred. To configure, please complete the provided form then continue with enrollment.");
                                     error!("{err}: {e:?}");
                                     ui_signals.s_error_msg.set(err.to_string());
                                     app_signals.s_reset_req.set(true);
@@ -425,7 +425,7 @@ pub(crate) fn app(
 
                                     let mgmt_key = get_pb_default(&yubikey);
                                     if yubikey.authenticate(&mgmt_key).is_err() {
-                                        let sm = format!("The YubiKey with serial number {} is not using the expected management key. Please reset the device then try again.", yubikey.serial());
+                                        let sm = format!("The YubiKey with serial number {} has not been configured for use with Purebred. To configure, please complete the provided form then continue with enrollment.", yubikey.serial());
                                         set_error(&sm, ui_signals.s_error_msg, ui_signals.s_cursor, ui_signals.s_disabled);
 
                                         // choice dialog is no longer used, show a toast then send the user to the reset form

--- a/pbyk/src/gui/gui_main.rs
+++ b/pbyk/src/gui/gui_main.rs
@@ -259,7 +259,7 @@ pub(crate) fn GuiMain() -> Element {
                     }
                     Err(e) => {
                         let err = format!(
-                            "The YubiKey with serial number {str_serial} is not using the expected management key. Please reset the device then try again."
+                            "The YubiKey with serial number {str_serial} has not been configured for use with Purebred. To configure, please complete the provided form then continue with enrollment."
                         );
                         error!("{err}: {e:?}");
                         do_reset = true;

--- a/pbyk/src/gui/reset.rs
+++ b/pbyk/src/gui/reset.rs
@@ -29,12 +29,19 @@ pub(crate) fn reset(
     macro_rules! show_error_dialog {
         () => {
             if !ui_signals.s_error_msg.read().is_empty() {
+                let context = ui_signals.s_error_msg.to_string();
+                let icon = if context.contains("management key") {
+                    Some(Icon::Info)
+                } else {
+                    Some(Icon::Error)
+                };
+
                 let _id = ui_signals.toast.write().popup(ToastInfo {
                     heading: Some("Reset Error".to_string()),
-                    context: ui_signals.s_error_msg.to_string(),
+                    context,
                     allow_toast_close: true,
                     position: dioxus_toast::Position::TopLeft,
-                    icon: Some(Icon::Error),
+                    icon,
                     hide_after: None,
                 });
                 ui_signals.s_error_msg.set(String::new());

--- a/pbyk/src/gui/reset.rs
+++ b/pbyk/src/gui/reset.rs
@@ -30,14 +30,14 @@ pub(crate) fn reset(
         () => {
             if !ui_signals.s_error_msg.read().is_empty() {
                 let context = ui_signals.s_error_msg.to_string();
-                let icon = if context.contains("management key") {
-                    Some(Icon::Info)
+                let (icon, heading) = if context.contains("has not been configured for use with Purebred") {
+                    (Some(Icon::Info), Some("Reset Device".to_string()))
                 } else {
-                    Some(Icon::Error)
+                    (Some(Icon::Error), Some("Reset Error".to_string()))
                 };
 
                 let _id = ui_signals.toast.write().popup(ToastInfo {
-                    heading: Some("Reset Error".to_string()),
+                    heading,
                     context,
                     allow_toast_close: true,
                     position: dioxus_toast::Position::TopLeft,

--- a/pbyk/src/main.rs
+++ b/pbyk/src/main.rs
@@ -864,8 +864,7 @@ async fn interactive_main() {
         if 8 != enroll_otp.len() || !enroll_otp.chars().all(|c| c.is_numeric()) {
             println!(
                 "{}",
-                "The enroll_otp value must be 8 characters long and only contain digits."
-                    .bold()
+                "The enroll_otp value must be 8 characters long and only contain digits.".bold()
             );
             return;
         }
@@ -900,8 +899,7 @@ async fn interactive_main() {
         if 8 != ukm_otp.len() || !ukm_otp.chars().all(|c| c.is_numeric()) {
             println!(
                 "{}",
-                "The ukm_otp value must be 8 characters long and only contain digits."
-                    .bold()
+                "The ukm_otp value must be 8 characters long and only contain digits.".bold()
             );
             return;
         }
@@ -936,12 +934,10 @@ async fn interactive_main() {
         if 8 != recover_otp.len() || !recover_otp.chars().all(|c| c.is_numeric()) {
             println!(
                 "{}",
-                "The recover_otp value must be 8 characters long and only contain digits."
-                    .bold()
+                "The recover_otp value must be 8 characters long and only contain digits.".bold()
             );
             return;
         }
-
 
         let oai = OtaActionInputs::new(
             &args.serial.as_ref().unwrap().to_string(), // allow unwrap where clap enforces presence

--- a/pbyk/src/main.rs
+++ b/pbyk/src/main.rs
@@ -746,7 +746,7 @@ async fn interactive_main() {
                 let mgmt_key = get_pb_default(&yubikey);
                 if yubikey.authenticate(&mgmt_key).is_err() {
                     println!(
-                        "{}: this YubiKey is not using the expected management key. Please reset the device then try again.",
+                        "{}: this YubiKey has not been configured for use with Purebred. To configure, please reset then device using the --reset-device option then continue with enrollment.",
                         "ERROR".bold()
                     );
                     return;

--- a/pbykcorelib/Cargo.toml
+++ b/pbykcorelib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbykcorelib"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88.0"
 

--- a/pbyklib/Cargo.toml
+++ b/pbyklib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbyklib"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88.0"
 


### PR DESCRIPTION
Displaying an error prompt for the expected behavior when using an out-of-the-box YubiKey is wrong. Apply a few fmt changes to old code.